### PR TITLE
Fix #2 blitvm path config

### DIFF
--- a/blitvm/blitvm_server.py
+++ b/blitvm/blitvm_server.py
@@ -794,6 +794,8 @@ blitlang.WHITELIST_FUNCTIONS.update(
         # wsgi
         "wsgiref.handlers.BaseHandler.start_response",
         "wsgiref.handlers.BaseHandler.write",
+        # Simple Cookie
+        "SimpleCookie.get",
     ]
 )
 

--- a/blitvm/ensure_blitvm.py
+++ b/blitvm/ensure_blitvm.py
@@ -1,7 +1,8 @@
-import blitlang
-import blitwsgi
 
 if __name__ == "__main__":
-    code = '''assert str(obj) == '<object object at 0x1234>', "blit-python not found on PATH"'''
+    assert str(object()) == '<object object at 0x1234>', "blit-python not found on PATH, make sure it is installed with pyenv and first on PATH"
 
+    import blitlang
+    import blitwsgi
+    code = '''assert str(obj) == '<object object at 0x1234>', "blit-python not found on PATH"'''
     blitlang.blit_eval(code, scope={"obj": object()})

--- a/readme.md
+++ b/readme.md
@@ -180,18 +180,18 @@ make mainnet
 Set as a runtime flag, assuming you checked out and built it in your home directory
 
 ```
-blitd start --blit.experimental_blitvm_path /home/[username]/blitchain/blitvm
+blitd start --blit.blitvm_path /home/[username]/blitchain/blitvm
 ```
 
 or set in `~/.blit/config/app.toml`
 ```
 [blit]
-  experimental_blitvm_path = /home/[username]/blitchain/blitvm"
+  blitvm_path = /home/[username]/blitchain/blitvm"
 ```
 
 or in an env var
 ```
-BLITD_BLIT_EXPERIMENTAL_BLITVM_PATH=/home/[username]/blitchain/blitvm
+BLITD_BLIT_BLITVM_PATH=/home/[username]/blitchain/blitvm
 blitd start
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,26 @@ make mainnet
 
 |:exclamation:  Note for running a node  |
 |:-----------------------------------------|
-| When **starting** the node you MUST use `$ $DAEMON_HOME/cosmovisor/current/bin/blitd start` from within the project directory and NOT using the globally linked binary. Otherwise you will get consensus errors. When using the binary as a client you can use the globally linked one like: `$ blitd` |
+| In order to run a node, you must set the path of blitvm for blitd to find if you install it globally |
+
+
+Set as a runtime flag, assuming you checked out and built it in your home directory
+
+```
+blitd start --blit.experimental_blitvm_path /home/[username]/blitchain/blitvm
+```
+
+or set in `~/.blit/config/app.toml`
+```
+[blit]
+  experimental_blitvm_path = /home/[username]/blitchain/blitvm"
+```
+
+or in an env var
+```
+BLITD_BLIT_EXPERIMENTAL_BLITVM_PATH=/home/[username]/blitchain/blitvm
+blitd start
+```
 
 Start syncing the mainnet
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -174,25 +174,26 @@ make mainnet
 
 |:exclamation:  Note for running a node  |
 |:-----------------------------------------|
-| In order to run a node, you must set the path of blitvm for blitd to find if you install it globally |
+| If you install it globally, to run a node you must set the path of blitvm |
 
 
-Set as a runtime flag, assuming you checked out and built it in your home directory
+Blit will check for value in the following priority:
 
+The flag on `blitd`
 ```
-blitd start --blit.blitvm_path /home/[username]/blitchain/blitvm
+blitd start --blit.blitvm_path /path/to/blitchain/blitvm/
+```
+
+or the environment variable
+```
+BLITD_BLIT_BLITVM_PATH=/path/to/blitchain/blitvm/
+blitd start
 ```
 
 or set in `~/.blit/config/app.toml`
 ```
 [blit]
-  blitvm_path = /home/[username]/blitchain/blitvm"
-```
-
-or in an env var
-```
-BLITD_BLIT_BLITVM_PATH=/home/[username]/blitchain/blitvm
-blitd start
+blitvm_path = "./blitvm"
 ```
 
 Start syncing the mainnet

--- a/src/app/ensure.go
+++ b/src/app/ensure.go
@@ -3,25 +3,30 @@ package app
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+
+	"github.com/spf13/viper"
 )
 
 func ensure() {
-	// Verify blit-python is installed
 
-	blitvmPath := os.Getenv("BLITVM_PATH")
-	if blitvmPath == "" {
-		blitvmPath = "./blitvm/"
-	}
-
-	out, runErr := exec.Command(
-		"python3", filepath.Join(blitvmPath, "ensure_blitvm.py"),
-	).CombinedOutput()
+	out, runErr := runBlitVmScript("ensure_blitvm.py")
 
 	if runErr != nil {
-		fmt.Println("Error running ensure_blitvm.", runErr, string(out))
-		fmt.Printf("BLITVM_PATH: %s\n", blitvmPath)
+		blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+
+		fmt.Println("Error running ensure_blitvm:", runErr, out)
+		fmt.Printf("blit.experimental_blitvm_path: %s\n", blitvmPath)
+		// if blitvmPath is relative, it's relative to the current working directory
+		if !filepath.IsAbs(blitvmPath) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Println("Error getting current working directory.", err)
+			} else {
+				fmt.Printf("current working directory: %s\nnormalized: %s\n", cwd, filepath.Join(cwd, blitvmPath))
+			}
+		}
+
 		os.Exit(42)
 	}
 

--- a/src/app/ensure.go
+++ b/src/app/ensure.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	blittypes "blit/x/blit/types"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,19 +14,39 @@ func ensure() {
 	out, runErr := runBlitVmScript("ensure_blitvm.py")
 
 	if runErr != nil {
-		blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+		blitvmPath := viper.GetString(blittypes.FlagBlitVMPath)
 
 		fmt.Println("Error running ensure_blitvm:", runErr, out)
-		fmt.Printf("blit.experimental_blitvm_path: %s\n", blitvmPath)
 		// if blitvmPath is relative, it's relative to the current working directory
+		fmt.Printf("%s: %s\n", blittypes.FlagBlitVMPath, blitvmPath)
 		if !filepath.IsAbs(blitvmPath) {
 			cwd, err := os.Getwd()
 			if err != nil {
 				fmt.Println("Error getting current working directory.", err)
 			} else {
+
 				fmt.Printf("current working directory: %s\nnormalized: %s\n", cwd, filepath.Join(cwd, blitvmPath))
+				fmt.Printf("If you want to use blitd globally, you MUST to set %s to an absolute path. Currently it is a relative path.\n", blittypes.FlagBlitVMPath)
 			}
 		}
+		// print multi line help
+		fmt.Println(`
+Assuming you checked out and built it in your home directory.
+Set as a runtime flag:
+----
+$ blitd start --blit.blitvm_path /home/[username]/blitchain/blitvm
+----
+
+or set in ~/.blit/config/app.toml:
+...
+[blit]
+  blitvm_path = "/home/[username]/blitchain/blitvm"
+...
+
+Or use an environment variable:
+...
+BLITD_BLIT_BLITVM_PATH=/home/[username]/blitchain/blitvm
+...`)
 
 		os.Exit(42)
 	}

--- a/src/app/runpy.go
+++ b/src/app/runpy.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+func runBlitVmScript(script string) (string, error) {
+
+	blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+	pyenv_root := os.Getenv("PYENV_ROOT")
+	if pyenv_root == "" {
+		fmt.Println("PYENV_ROOT is not set. Please set it to the root of your pyenv installation.")
+		os.Exit(41)
+	}
+
+	pythonExe := filepath.Join(pyenv_root, "versions", "blit-python", "bin", "python")
+
+	out, runErr := exec.Command(pythonExe, filepath.Join(blitvmPath, script)).CombinedOutput()
+	return string(out), runErr
+}

--- a/src/app/runpy.go
+++ b/src/app/runpy.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	blittypes "blit/x/blit/types"
+
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +13,7 @@ import (
 
 func runBlitVmScript(script string) (string, error) {
 
-	blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+	blitvmPath := viper.GetString(blittypes.FlagBlitVMPath)
 	pyenv_root := os.Getenv("PYENV_ROOT")
 	if pyenv_root == "" {
 		fmt.Println("PYENV_ROOT is not set. Please set it to the root of your pyenv installation.")

--- a/src/x/blit/module/module.go
+++ b/src/x/blit/module/module.go
@@ -231,7 +231,7 @@ func AddModuleInitFlags(startCmd *cobra.Command) {
 	startCmd.Flags().Bool(types.FlagBlitScriptDebugMode, defaults.ScriptDebugMode, "Debug mode for Blitchain scripts")
 	startCmd.Flags().String(types.FlagPublicBlitRestAPIURL, defaults.PublicRestAPIURL, "Public REST API URL for blitjs")
 	startCmd.Flags().String(types.FlagPublicBlitCometRPCURL, defaults.PublicCometRPCURL, "Public Comet RPC URL for blitjs")
-	startCmd.Flags().String(types.FlagBlitVMPath, defaults.BlitVMPath, "EXPERIMENTAL: Path to blitvm executable")
+	startCmd.Flags().String(types.FlagBlitVMPath, defaults.BlitVMPath, "Path to blitvm executable")
 
 }
 

--- a/src/x/blit/types/types.go
+++ b/src/x/blit/types/types.go
@@ -10,7 +10,7 @@ const (
 	FlagBlitScriptDebugMode   = "blit.script_debug_mode"
 	FlagPublicBlitRestAPIURL  = "blit.public_rest_api_url"
 	FlagPublicBlitCometRPCURL = "blit.public_comet_rpc_url"
-	FlagBlitVMPath            = "blit.experimental_blitvm_path"
+	FlagBlitVMPath            = "blit.blitvm_path"
 )
 
 // BlitConfig is the extra config required for wasm
@@ -50,8 +50,8 @@ script_debug_mode = %v
 public_rest_api_url = "%s"
 # Public Comet RPC URL for blitjs
 public_comet_rpc_url = "%s"
-# EXPERIMENTAL: Path to blitvm executable
-experimental_blitvm_path = "%s"
+# Path to blitvm executable
+blitvm_path = "%s"
 
 `, c.ScriptDebugMode, c.PublicRestAPIURL, c.PublicCometRPCURL, c.BlitVMPath)
 }

--- a/src/x/script/keeper/keeper.go
+++ b/src/x/script/keeper/keeper.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -559,9 +560,12 @@ func (k Keeper) evalScript(goCtx context.Context, scriptCtx *EvalScriptContext, 
 		return nil, err
 	}
 
+	pyenv_root := os.Getenv("PYENV_ROOT")
+	pythonExe := filepath.Join(pyenv_root, "versions", "blit-python", "bin", "python")
+
 	blitvmPath := viper.GetString("blit.experimental_blitvm_path")
 	out, runErr := exec.Command(
-		"python3", filepath.Join(blitvmPath, "blitvm_server.py"),
+		pythonExe, filepath.Join(blitvmPath, "blitvm_server.py"),
 		port,
 		scriptCtx.CallerAddress,
 		valFound.Address,

--- a/src/x/script/keeper/keeper.go
+++ b/src/x/script/keeper/keeper.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/spf13/viper"
 
+	blittypes "blit/x/blit/types"
 	"blit/x/script/types"
 
 	"github.com/gorilla/rpc"
@@ -563,7 +564,7 @@ func (k Keeper) evalScript(goCtx context.Context, scriptCtx *EvalScriptContext, 
 	pyenv_root := os.Getenv("PYENV_ROOT")
 	pythonExe := filepath.Join(pyenv_root, "versions", "blit-python", "bin", "python")
 
-	blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+	blitvmPath := viper.GetString(blittypes.FlagBlitVMPath)
 	out, runErr := exec.Command(
 		pythonExe, filepath.Join(blitvmPath, "blitvm_server.py"),
 		port,

--- a/src/x/script/keeper/query_web.go
+++ b/src/x/script/keeper/query_web.go
@@ -26,8 +26,7 @@ func (k Keeper) Web(goCtx context.Context, req *types.QueryWebRequest) (*types.Q
 	if ctx.GasMeter().Limit() < 1 || ctx.GasMeter().Limit() > MAX_QUERY_GAS {
 		ctx = ctx.WithGasMeter(storetypes.NewGasMeter(MAX_QUERY_GAS))
 	}
-	goCtx = sdk.WrapSDKContext(ctx)
-	val, found := k.RunWeb(goCtx, req.Address, req.Httprequest)
+	val, found := k.RunWeb(ctx, req.Address, req.Httprequest)
 	if !found {
 		return nil, errorsmod.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("Script at address '%v' not set", req.Address))
 	}

--- a/src/x/script/keeper/script.go
+++ b/src/x/script/keeper/script.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	blittypes "blit/x/blit/types"
 	"blit/x/script/types"
 
 	"cosmossdk.io/store/prefix"
@@ -105,7 +106,7 @@ func (k Keeper) RunWeb(goCtx context.Context, index string, httpreq string) (val
 		log.Fatal(err)
 	}
 
-	blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+	blitvmPath := viper.GetString(blittypes.FlagBlitVMPath)
 	pyenv_root := os.Getenv("PYENV_ROOT")
 	pythonExe := filepath.Join(pyenv_root, "versions", "blit-python", "bin", "python")
 

--- a/src/x/script/keeper/script.go
+++ b/src/x/script/keeper/script.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -105,9 +106,11 @@ func (k Keeper) RunWeb(goCtx context.Context, index string, httpreq string) (val
 	}
 
 	blitvmPath := viper.GetString("blit.experimental_blitvm_path")
+	pyenv_root := os.Getenv("PYENV_ROOT")
+	pythonExe := filepath.Join(pyenv_root, "versions", "blit-python", "bin", "python")
 
 	cmd := exec.Command(
-		"python3", filepath.Join(blitvmPath, "blitwsgi.py"),
+		pythonExe, filepath.Join(blitvmPath, "blitwsgi.py"),
 		port,
 		valFound.Address,
 		string(blockInfoJson),


### PR DESCRIPTION
This fixes #2 because the old `BLITVM_PATH ` evn var was still being used and not the `blit.blitvm_path ` config.
Also finds the correct blit-python version from `PYENV_ROOT` env var
https://github.com/pyenv/pyenv?tab=readme-ov-file#set-up-your-shell-environment-for-pyenv

```
PYENV_ROOT=/home/[user]/.pyenv/ # set this in your .bashrc and in the systemd config
```

Blit will check for the following in order:

The flag on `blitd`
```
blitd start --blit.blitvm_path /path/to/blitchain/blitvm/
```

or the environment variable
```
BLITD_BLIT_BLITVM_PATH=/path/to/blitchain/blitvm/
blitd start
```

or set in `~/.blit/config/app.toml`
```
[blit]
blitvm_path = "/path/to/blitchain/blitvm/"
```
